### PR TITLE
exception on invalid zip

### DIFF
--- a/src/unzip.c
+++ b/src/unzip.c
@@ -415,7 +415,8 @@ extern unzFile ZEXPORT unzOpen (const char *path, uint8_t *pData, uint32_t u32Da
 	if (err!=UNZ_OK)
 	{
 //		fclose(fin);
-        (*pzf->pfnClose)(pzf);
+		if (pzf->pfnClose != NULL)
+        	(*pzf->pfnClose)(pzf);
 		return NULL;
 	}
 
@@ -1017,7 +1018,7 @@ extern int ZEXPORT unzOpenCurrentFile (file)
 extern int ZEXPORT unzReadCurrentFile  (file, buf, len)
 	unzFile file;
 	voidp buf;
-	unsigned len;
+	uLong len;
 {
 	int err=UNZ_OK;
 	uInt iRead = 0;

--- a/src/unzip.h
+++ b/src/unzip.h
@@ -268,7 +268,7 @@ extern int ZEXPORT unzCloseCurrentFile OF((unzFile file));
 												
 extern int ZEXPORT unzReadCurrentFile OF((unzFile file, 
 					  voidp buf,
-					  unsigned len));
+					  uLong len));
 /*
   Read bytes from the current file (opened by unzOpenCurrentFile)
   buf contain buffer where data must be copied

--- a/src/unzipLIB.cpp
+++ b/src/unzipLIB.cpp
@@ -17,7 +17,7 @@
 //===========================================================================
 #include "unzipLIB.h"
 
-int UNZIP::openZIP(uint8_t *pData, int iDataSize)
+int UNZIP::openZIP(uint8_t *pData, uint32_t iDataSize)
 {
     _zip.zHandle = unzOpen(NULL, pData, iDataSize, &_zip, NULL, NULL, NULL, NULL);
     if (_zip.zHandle == NULL) {
@@ -55,7 +55,7 @@ int UNZIP::closeCurrentFile()
     return _zip.iLastError;
 } /* closeCurrentFile() */
 
-int UNZIP::readCurrentFile(uint8_t *buffer, int iLength)
+int UNZIP::readCurrentFile(uint8_t *buffer, uint32_t iLength)
 {
     return unzReadCurrentFile((unzFile)_zip.zHandle, buffer, iLength);
 } /* readCurrentFile() */

--- a/src/unzipLIB.h
+++ b/src/unzipLIB.h
@@ -40,12 +40,12 @@
 class UNZIP
 {
   public:
-    int openZIP(uint8_t *pData, int iDataSize);
+    int openZIP(uint8_t *pData, uint32_t iDataSize);
     int openZIP(const char *szFilename, ZIP_OPEN_CALLBACK *pfnOpen, ZIP_CLOSE_CALLBACK *pfnClose, ZIP_READ_CALLBACK *pfnRead, ZIP_SEEK_CALLBACK *pfnSeek);
     int closeZIP();
     int openCurrentFile();
     int closeCurrentFile();
-    int readCurrentFile(uint8_t *buffer, int iLength);
+    int readCurrentFile(uint8_t *buffer, uint32_t iLength);
     int getCurrentFilePos();
     int gotoFirstFile();
     int gotoNextFile();


### PR DESCRIPTION
`Guru Meditation Error: Core  1 panic'ed (InstrFetchProhibited). Exception was unhandled.`

I zipped the file with gzip and got this exception. After debugging a while, I saw that the handler is not closed correctly if the zip is invalid.

There is also a problem with the int as parameter. On some cpus this is a 16-bit number and so you cast the size to int16 (max size 32kb). In the internal library it is already uint32_t, so I changed also the type on the class.