### PR TITLE
Fix linux demo: use cli arg instead of hardcoded val

### DIFF
--- a/Linux/main.c
+++ b/Linux/main.c
@@ -68,8 +68,8 @@ ZIPFILE zpf;
     rc = unzGetGlobalComment(zHandle, (char *)szTemp, sizeof(szTemp));
     printf("Global Comment: %s\n", szTemp);
     
-//    rc = unzLocateFile(zHandle, argv[2], 2);
-    rc = unzLocateFile(zHandle, "key.bmp", 2);
+    rc = unzLocateFile(zHandle, argv[2], 2);
+
     if (rc != UNZ_OK) /* Report the file not found */
     {
         printf("file %s not found within archive\n", argv[2]);


### PR DESCRIPTION
Hi, I was testing out the linux cli example for some epub parsing and found that the filename argument is not taken into account, seems to have been commented out for some testing